### PR TITLE
Feature - drawio diagrams

### DIFF
--- a/confluence-markdown-export.py
+++ b/confluence-markdown-export.py
@@ -26,7 +26,7 @@ NONCONVERTIBLE_TAGS = [
     'img.confluence-external-resource',
 ]
 
-DRAW_IO_DIAGRAM_URI_REGEX = "/rest/drawio/1.0/diagram/crud/.*'"
+DRAW_IO_DIAGRAM_URI_REGEX = "(/rest/drawio/1.0/diagram/crud/.*?)'"
 
 
 class ExportException(Exception):
@@ -123,7 +123,7 @@ class Exporter:
 
         i = 0
         for drawio_img in soup.find_all('img', {'class': 'drawio-diagram-image'}):
-            drawio = self.__confluence.get(diagram_urls[0][:-1]) # Last symbol is `'`. TODO: Fix regex
+            drawio = self.__confluence.get(diagram_urls[i])
             if not drawio:
                 continue
 

--- a/confluence-markdown-export.py
+++ b/confluence-markdown-export.py
@@ -1,14 +1,17 @@
 import os
-import json
+import re
 import argparse
 
 from urllib.parse import urlparse, parse_qs, unquote
 
 import requests
 import bs4
-from markdownify import MarkdownConverter
 from atlassian import Confluence, utils
 from atlassian.errors import ApiError
+
+from helpers import parse_cookies, sanitize_filename
+from markdown import SkipTableMarkdownConverter
+from drawio import DrawioConverter
 
 
 ATTACHMENT_FOLDER_NAME = "attachments"
@@ -23,48 +26,11 @@ NONCONVERTIBLE_TAGS = [
     'img.confluence-external-resource',
 ]
 
+DRAW_IO_DIAGRAM_URI_REGEX = "/rest/drawio/1.0/diagram/crud/.*'"
+
 
 class ExportException(Exception):
     pass
-
-
-def parse_cookies():
-    with open('cookies.json') as json_file:
-        data = json.load(json_file)
-
-    return data
-
-
-def sanitize_filename(document_name_raw):
-    document_name = document_name_raw
-
-    for invalid in ["\\", "/"]:
-        if invalid in document_name:
-            print("Dangerous page title: \"{}\", \"{}\" found, replacing it with \"_\"".format(
-                document_name,
-                invalid))
-            document_name = document_name.replace(invalid, "_")
-
-    document_name = ' '.join(document_name.split()) # replace multiple whitespaces with single one
-
-    return document_name
-
-
-class SkipTableMarkdownConverter(MarkdownConverter):
-    def process_tag(self, node, convert_as_inline, children_only=False):
-        if node.name != 'table':
-            return super(SkipTableMarkdownConverter, self).process_tag(node, convert_as_inline, children_only)
-
-        for el in node.find_all():
-            del el['class']
-
-        text = str(node.prettify())
-
-        for img in node.find_all('img'):
-            converted_img = self.convert_img(img, '', convert_as_inline)
-            text = text.replace(str(img), converted_img)
-
-        return f'\n\n{text}\n\n'
 
 
 class Exporter:
@@ -76,12 +42,6 @@ class Exporter:
         self.__confluence = Confluence(url=self.__url, cookies=self.__cookies)
         self.__seen = set()
         self.__no_attach = no_attach
-
-    def __parse_cookie_file(self, filepath):
-        with open(filepath) as json_file:
-            data = json.load(json_file)
-
-        return data
 
     def __dump_page(self, src_id, parents):
         if src_id in self.__seen:
@@ -113,6 +73,11 @@ class Exporter:
         page_output_dir = os.path.dirname(page_filename)
         os.makedirs(page_output_dir, exist_ok=True)
         print("Saving to {}".format(" / ".join(page_location)))
+
+        if 'drawio-diagram-image' in content:
+            print('Converting draw.io images')
+            content = self.__content_with_embedded_drawio_images(content, page_id)
+
         with open(page_filename, "w") as f:
             f.write(content)
 
@@ -149,6 +114,27 @@ class Exporter:
                 print(f"Failed to dump child - {child_id}")
                 continue
     
+    def __content_with_embedded_drawio_images(self, content, page_id):
+        plain_page = self.__confluence.get_page_by_id(page_id, expand="body.view")
+        plain_content = plain_page['body']['view']['value']
+        diagram_urls = re.findall(DRAW_IO_DIAGRAM_URI_REGEX, plain_content)
+
+        soup = bs4.BeautifulSoup(content, 'html.parser')
+
+        i = 0
+        for drawio_img in soup.find_all('img', {'class': 'drawio-diagram-image'}):
+            drawio = self.__confluence.get(diagram_urls[0][:-1]) # Last symbol is `'`. TODO: Fix regex
+            if not drawio:
+                continue
+
+            embedded_diagram_data = DrawioConverter.convert_xml_to_base64_png(drawio['xml'])
+            if embedded_diagram_data:
+                drawio_img['src'] = f'data:image/png;base64,{embedded_diagram_data}'
+
+            i += 1
+
+        return str(soup)
+
     def dump(self):
         space = self.__confluence.get_space(self.__space_key, expand='description.plain,homepage')
         print("Processing space", self.__space_key)
@@ -165,7 +151,7 @@ class Exporter:
 class Converter:
     def __init__(self, out_dir, gitlab_wikis_path, url):
         self.__out_dir = out_dir
-        self.gitlab_wikis_path = gitlab_wikis_path
+        self.__gitlab_wikis_path = gitlab_wikis_path
         self.__confluence = Confluence(url=url, cookies=parse_cookies())
 
     def recurse_findfiles(self, path):
@@ -286,7 +272,7 @@ class Converter:
             for parent in page['ancestors']:
                 parent_slug += f"/{parent['title'].replace(' ', '-')}" if parent.get('title') else ''
 
-            page_link['href'] = f"{self.gitlab_wikis_path}{parent_slug}/{page['title'].replace(' ', '-')}"
+            page_link['href'] = f"{self.__gitlab_wikis_path}{parent_slug}/{page['title'].replace(' ', '-')}"
             del page_link['title']
 
         return soup

--- a/drawio.py
+++ b/drawio.py
@@ -1,0 +1,87 @@
+from urllib.parse import quote, unquote
+import os
+import xml.etree.ElementTree as ET
+import zlib
+import base64
+
+XML_FILEPATH = 'drawio.xml'
+PNG_FILEPATH = 'drawio.png'
+
+DRAW_IO_CONVERT_XML_TO_PNG_CMD = f'/Applications/draw.io.app/Contents/MacOS/draw.io -x -f png -e {XML_FILEPATH}'
+
+
+class DrawioConverter:
+    @classmethod
+    def convert_xml_to_base64_png(cls, xml):
+        if not cls.__create_xml_file(xml):
+            return
+
+        # TODO: Move xml to png convertation to this class to avoid relying on `draw.io` app
+        os.system(DRAW_IO_CONVERT_XML_TO_PNG_CMD)
+
+        try:
+            base64_png = base64.b64encode(open(PNG_FILEPATH, 'rb').read()).decode('utf-8')
+        except Exception as e:
+            print(f"Failed to convert XML to PNG, error - {e}")
+            base64_png = None
+        finally:
+            cls.__remove_created_files()
+            return base64_png
+
+    @classmethod
+    def __create_xml_file(cls, xml):
+        try:
+            with open(XML_FILEPATH, 'w') as file:
+                file.write(cls.__mx_graph_model(xml))
+        except Exception as e:
+            print(f"Failed to create XML file, error - {e}")
+            return False
+
+        return True
+
+    # TODO: Use tempfiles?
+    @classmethod
+    def __remove_created_files(cls):
+        filepaths_to_delete = [filepath for filepath in [XML_FILEPATH, PNG_FILEPATH] if os.path.exists(filepath)]
+        for filepath in filepaths_to_delete:
+            os.remove(filepath)
+
+    # https://stackoverflow.com/a/69975753
+    @classmethod
+    def __mx_graph_model(cls, xml):
+        uri_decoded_data = cls.__js_decode_uri_component(xml)
+
+        ## Extract diagram data from resulting XML
+        root = ET.fromstring(uri_decoded_data)
+        diagram_data = next(el.text for el in root if el.tag == 'diagram')
+
+        ## Decode Base64
+        diagram_data = cls.__js_atob(diagram_data)
+        decompressed_diagram_data = cls.__pako_inflate_raw(diagram_data)
+
+        ## Turn decompressed data into a usable string
+        string_diagram_data = cls.__js_bytes_to_string(decompressed_diagram_data)
+        string_diagram_data = cls.__js_decode_uri_component(string_diagram_data)
+
+        return string_diagram_data
+
+    @classmethod
+    def __js_decode_uri_component(cls, data):
+        return unquote(data)
+
+    @classmethod
+    def __js_bytes_to_string(cls, data):
+        return data.decode('iso-8859-1')
+
+    @classmethod
+    def __js_atob(cls, data):
+        return base64.b64decode(data)
+
+    @classmethod
+    def __pako_inflate_raw(cls, data):
+        decompress = zlib.decompressobj(-15)
+
+        decompressed_data = decompress.decompress(data)
+        decompressed_data += decompress.flush()
+
+        return decompressed_data

--- a/drawio.py
+++ b/drawio.py
@@ -39,7 +39,6 @@ class DrawioConverter:
 
         return True
 
-    # TODO: Use tempfiles?
     @classmethod
     def __remove_created_files(cls):
         filepaths_to_delete = [filepath for filepath in [XML_FILEPATH, PNG_FILEPATH] if os.path.exists(filepath)]

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,26 @@
+import json
+
+
+COOKIES_FILEPATH = 'cookies.json'
+
+
+def parse_cookies():
+    with open(COOKIES_FILEPATH) as json_file:
+        data = json.load(json_file)
+
+    return data
+
+
+def sanitize_filename(document_name_raw):
+    document_name = document_name_raw
+
+    for invalid in ["\\", "/"]:
+        if invalid in document_name:
+            print("Dangerous page title: \"{}\", \"{}\" found, replacing it with \"_\"".format(
+                document_name,
+                invalid))
+            document_name = document_name.replace(invalid, "_")
+
+    document_name = ' '.join(document_name.split()) # replace multiple whitespaces with single one
+
+    return document_name

--- a/markdown.py
+++ b/markdown.py
@@ -1,0 +1,18 @@
+from markdownify import MarkdownConverter
+
+
+class SkipTableMarkdownConverter(MarkdownConverter):
+    def process_tag(self, node, convert_as_inline, children_only=False):
+        if node.name != 'table':
+            return super(SkipTableMarkdownConverter, self).process_tag(node, convert_as_inline, children_only)
+
+        for el in node.find_all():
+            del el['class']
+
+        text = str(node.prettify())
+
+        for img in node.find_all('img'):
+            converted_img = self.convert_img(img, '', convert_as_inline)
+            text = text.replace(str(img), converted_img)
+
+        return f'\n\n{text}\n\n'


### PR DESCRIPTION
## Problem
- Script gets Confluence page HTML value by API request with `expand=body.export_view`. So draw.io images are exported as images without meta information about diagram.
- Due to that this images cannot be opened & edited as diargams in diagrams.net (cause they are plain images)

## Solution
- API request with `expand=body.view` contains API path to diagram data (provided by Draw.io Plugin API)
- By this path we can get `xml` data of diagram. This data is converted to `base64` png data (with meta information about diagram)

## TODO
- Conversion from `xml` to `base64` png is done by native draw.io application. Need to find & implement logic of converting `xml` to `base64` png in codebase. Reference - https://github.com/jgraph/drawio

## Reference
- Conversion of draw.io `xml` is implemented by SO answer - https://stackoverflow.com/a/69975753

## Additional changes
- Beautified code - split logic to separate files

## Requirements
- `draw.io` application for MacOS